### PR TITLE
[v3] eliminates deps array and relies on argument ref equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
 ## [Unreleased]
-### Change
+### Changed
 - No sub directory import (BREAKING CHANGE)
 - useAsyncTaskAxios/useAxios requires axios instance (BREAKING CHANGE)
+- No deps array, arguments should be memoized in caller (BREAKING CHANGE)
 
 ## [2.1.0] - 2019-04-16
 ### Changed

--- a/dist/use-async-combine-all.js
+++ b/dist/use-async-combine-all.js
@@ -33,6 +33,8 @@ exports.useAsyncCombineAll = void 0;
 
 require("regenerator-runtime/runtime");
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
@@ -48,7 +50,7 @@ var useAsyncCombineAll = function useAsyncCombineAll() {
     asyncTasks[_key] = arguments[_key];
   }
 
-  var task = (0, _useAsyncTask.useAsyncTask)(
+  var task = (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
@@ -81,10 +83,12 @@ var useAsyncCombineAll = function useAsyncCombineAll() {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), asyncTasks.map(function (_ref2) {
+  }(), // TODO Do we have a better way?
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  asyncTasks.map(function (_ref2) {
     var start = _ref2.start;
     return start;
-  }));
+  })));
   return _objectSpread({}, task, {
     pending: asyncTasks.some(function (_ref3) {
       var pending = _ref3.pending;

--- a/dist/use-async-combine-race.js
+++ b/dist/use-async-combine-race.js
@@ -37,6 +37,8 @@ require("regenerator-runtime/runtime");
 
 var _react = require("react");
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
@@ -58,7 +60,7 @@ var useAsyncCombineRace = function useAsyncCombineRace() {
       callback.current(asyncTasks);
     }
   });
-  var task = (0, _useAsyncTask.useAsyncTask)(
+  var task = (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
@@ -109,10 +111,12 @@ var useAsyncCombineRace = function useAsyncCombineRace() {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), asyncTasks.map(function (_ref3) {
+  }(), // TODO Do we have a better way?
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  asyncTasks.map(function (_ref3) {
     var start = _ref3.start;
     return start;
-  }));
+  })));
   (0, _react.useEffect)(function () {
     var cleanup = function cleanup() {
       callback.current = null;

--- a/dist/use-async-combine-seq.js
+++ b/dist/use-async-combine-seq.js
@@ -37,6 +37,8 @@ require("regenerator-runtime/runtime");
 
 var _react = require("react");
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
@@ -58,7 +60,7 @@ var useAsyncCombineSeq = function useAsyncCombineSeq() {
       callback.current(asyncTasks);
     }
   });
-  var task = (0, _useAsyncTask.useAsyncTask)(
+  var task = (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
@@ -114,10 +116,12 @@ var useAsyncCombineSeq = function useAsyncCombineSeq() {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), asyncTasks.map(function (_ref3) {
+  }(), // TODO Do we have a better way?
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  asyncTasks.map(function (_ref3) {
     var start = _ref3.start;
     return start;
-  }));
+  })));
   (0, _react.useEffect)(function () {
     var cleanup = function cleanup() {
       callback.current = null;

--- a/dist/use-async-task-axios.js
+++ b/dist/use-async-task-axios.js
@@ -21,6 +21,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.useAxios = exports.useAsyncTaskAxios = void 0;
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 var _useAsyncRun = require("./use-async-run");
@@ -29,8 +31,8 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var useAsyncTaskAxios = function useAsyncTaskAxios(axios, config, deps) {
-  return (0, _useAsyncTask.useAsyncTask)(function (abortController) {
+var useAsyncTaskAxios = function useAsyncTaskAxios(axios, config) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
     var source = axios.CancelToken.source();
     abortController.signal.addEventListener('abort', function () {
       source.cancel('canceled');
@@ -38,7 +40,7 @@ var useAsyncTaskAxios = function useAsyncTaskAxios(axios, config, deps) {
     return axios(_objectSpread({}, config, {
       cancelToken: source.token
     }));
-  }, deps);
+  }, [axios, config]));
 };
 
 exports.useAsyncTaskAxios = useAsyncTaskAxios;

--- a/dist/use-async-task-delay.js
+++ b/dist/use-async-task-delay.js
@@ -15,6 +15,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.useAsyncTaskDelay = void 0;
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 var createAbortError = function createAbortError(message) {
@@ -27,18 +29,18 @@ var createAbortError = function createAbortError(message) {
   }
 };
 
-var useAsyncTaskDelay = function useAsyncTaskDelay(milliSeconds, deps) {
-  return (0, _useAsyncTask.useAsyncTask)(function (abortController) {
+var useAsyncTaskDelay = function useAsyncTaskDelay(delay) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
     return new Promise(function (resolve, reject) {
       var id = setTimeout(function () {
         resolve(true);
-      }, milliSeconds);
+      }, typeof delay === 'function' ? delay() : delay);
       abortController.signal.addEventListener('abort', function () {
         clearTimeout(id);
         reject(createAbortError('timer aborted'));
       });
     });
-  }, deps);
+  }, [delay]));
 };
 
 exports.useAsyncTaskDelay = useAsyncTaskDelay;

--- a/dist/use-async-task-fetch.js
+++ b/dist/use-async-task-fetch.js
@@ -29,6 +29,8 @@ exports.useFetch = exports.useAsyncTaskFetch = void 0;
 
 require("regenerator-runtime/runtime");
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 var _useAsyncRun = require("./use-async-run");
@@ -56,7 +58,7 @@ var createFetchError = function createFetchError(message) {
 var useAsyncTaskFetch = function useAsyncTaskFetch(input) {
   var init = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultInit;
   var readBody = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : defaultReadBody;
-  return (0, _useAsyncTask.useAsyncTask)(
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
@@ -101,7 +103,7 @@ var useAsyncTaskFetch = function useAsyncTaskFetch(input) {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), [input, init, readBody]);
+  }(), [input, init, readBody]));
 };
 
 exports.useAsyncTaskFetch = useAsyncTaskFetch;

--- a/dist/use-async-task-timeout.js
+++ b/dist/use-async-task-timeout.js
@@ -15,6 +15,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.useAsyncTaskTimeout = void 0;
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 var createAbortError = function createAbortError(message) {
@@ -27,8 +29,8 @@ var createAbortError = function createAbortError(message) {
   }
 };
 
-var useAsyncTaskTimeout = function useAsyncTaskTimeout(func, delay, deps) {
-  return (0, _useAsyncTask.useAsyncTask)(function (abortController) {
+var useAsyncTaskTimeout = function useAsyncTaskTimeout(func, delay) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
     return new Promise(function (resolve, reject) {
       var id = setTimeout(function () {
         resolve(func());
@@ -38,7 +40,7 @@ var useAsyncTaskTimeout = function useAsyncTaskTimeout(func, delay, deps) {
         reject(createAbortError('timer aborted'));
       });
     });
-  }, deps);
+  }, [func, delay]));
 };
 
 exports.useAsyncTaskTimeout = useAsyncTaskTimeout;

--- a/dist/use-async-task-wasm.js
+++ b/dist/use-async-task-wasm.js
@@ -13,6 +13,8 @@ exports.useWasm = exports.useAsyncTaskWasm = void 0;
 
 require("regenerator-runtime/runtime");
 
+var _useMemoOne = require("use-memo-one");
+
 var _useAsyncTask = require("./use-async-task");
 
 var _useAsyncRun = require("./use-async-run");
@@ -25,7 +27,7 @@ var defaultImportObject = {};
 
 var useAsyncTaskWasm = function useAsyncTaskWasm(input) {
   var importObject = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultImportObject;
-  return (0, _useAsyncTask.useAsyncTask)(
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
@@ -70,7 +72,7 @@ var useAsyncTaskWasm = function useAsyncTaskWasm(input) {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), [input, importObject]);
+  }(), [input, importObject]));
 };
 
 exports.useAsyncTaskWasm = useAsyncTaskWasm;

--- a/dist/use-async-task.js
+++ b/dist/use-async-task.js
@@ -105,7 +105,7 @@ var reducer = function reducer(state, action) {
   }
 };
 
-var useAsyncTask = function useAsyncTask(func, deps) {
+var useAsyncTask = function useAsyncTask(func) {
   var _useReducer = (0, _react.useReducer)(reducer, initialState),
       _useReducer2 = _slicedToArray(_useReducer, 2),
       state = _useReducer2[0],
@@ -199,8 +199,7 @@ var useAsyncTask = function useAsyncTask(func, deps) {
     };
 
     return cleanup;
-  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, [func]);
   return state;
 };
 

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { useAsyncRun, useAsyncTaskTimeout } from 'react-hooks-async';
 
 const Err = ({ error }) => (
-  <div>Error:{error.message}</div>
+  <div>Error: {error.message}</div>
 );
 
 const Waiting = ({ abort }) => (
@@ -17,7 +17,7 @@ const Waiting = ({ abort }) => (
 const renderHi = () => <h1>Hi</h1>;
 
 const DelayedMessage = ({ delay }) => {
-  const asyncTask = useAsyncTaskTimeout(renderHi, delay, [renderHi, delay]);
+  const asyncTask = useAsyncTaskTimeout(renderHi, delay);
   useAsyncRun(asyncTask);
   const {
     pending,
@@ -27,7 +27,7 @@ const DelayedMessage = ({ delay }) => {
   } = asyncTask;
   if (error) return <Err error={error} />;
   if (pending) return <Waiting abort={abort} />;
-  return <div>Result:{result}</div>;
+  return <div>Result: {result}</div>;
 };
 
 const App = () => (

--- a/examples/02_typescript/src/DisplayRemoteData.tsx
+++ b/examples/02_typescript/src/DisplayRemoteData.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAsyncRun, useAsyncTaskFetch } from 'react-hooks-async';
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -26,7 +26,7 @@ const DisplayRemoteData: React.FC<{ id: string }> = ({ id }) => {
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;
-  return <div>RemoteData:{result.title}</div>;
+  return <div>RemoteData: {result.title}</div>;
 };
 
 export default DisplayRemoteData;

--- a/examples/03_startbutton/src/DisplayRemoteData.tsx
+++ b/examples/03_startbutton/src/DisplayRemoteData.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAsyncTaskFetch } from 'react-hooks-async';
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -28,7 +28,7 @@ const DisplayRemoteData: React.FC<{ id: string }> = ({ id }) => {
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;
-  return <div>RemoteData:{result.title}</div>;
+  return <div>RemoteData: {result.title}</div>;
 };
 
 export default DisplayRemoteData;

--- a/examples/03_startbutton/src/UserInfo.tsx
+++ b/examples/03_startbutton/src/UserInfo.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useAsyncTaskFetch } from 'react-hooks-async';
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -36,7 +36,7 @@ const UserInfo: React.FC<{ id: string }> = ({ id }) => {
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;
-  return <div>First Name:{result.data.first_name}</div>;
+  return <div>First Name: {result.data.first_name}</div>;
 };
 
 export default UserInfo;

--- a/examples/04_typeahead/package.json
+++ b/examples/04_typeahead/package.json
@@ -11,7 +11,8 @@
     "react-dom": "latest",
     "react-hooks-async": "latest",
     "react-scripts": "^2.1.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.1.6",
+    "use-memo-one": "^1.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/04_typeahead/src/GitHubSearch.tsx
+++ b/examples/04_typeahead/src/GitHubSearch.tsx
@@ -1,4 +1,7 @@
+/* eslint no-new-wrappers: off */
+
 import * as React from 'react';
+import { useCallbackOne as useCallback } from 'use-memo-one';
 
 import {
   useAsyncCombineSeq,
@@ -8,7 +11,7 @@ import {
 } from 'react-hooks-async';
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -30,7 +33,8 @@ type Result = {
 
 const GitHubSearch: React.FC<{ query: string }> = ({ query }) => {
   const url = `https://api.github.com/search/repositories?q=${query}`;
-  const delayTask = useAsyncTaskDelay(500, [query]);
+  const delay = useCallback(() => 500, [url]); // eslint-disable-line react-hooks/exhaustive-deps
+  const delayTask = useAsyncTaskDelay(delay);
   const fetchTask = useAsyncTaskFetch<Result>(url);
   const combinedTask = useAsyncCombineSeq(delayTask, fetchTask);
   useAsyncRun(combinedTask);

--- a/examples/05_axios/package.json
+++ b/examples/05_axios/package.json
@@ -12,7 +12,8 @@
     "react-dom": "latest",
     "react-hooks-async": "latest",
     "react-scripts": "^2.1.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.1.6",
+    "use-memo-one": "^1.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/05_axios/src/DisplayRemoteData.tsx
+++ b/examples/05_axios/src/DisplayRemoteData.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import axios from 'axios';
+import { useMemoOne as useMemo } from 'use-memo-one';
 
 import { useAsyncRun, useAsyncTaskAxios } from 'react-hooks-async';
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -22,7 +23,8 @@ type Response = {
 
 const DisplayRemoteData: React.FC<{ id: string }> = ({ id }) => {
   const url = `https://jsonplaceholder.typicode.com/posts/${id}`;
-  const asyncTask = useAsyncTaskAxios<Response>(axios, { url }, [url]);
+  const config = useMemo(() => ({ url }), [url]);
+  const asyncTask = useAsyncTaskAxios<Response>(axios, config);
   useAsyncRun(asyncTask);
   const {
     pending,
@@ -33,7 +35,7 @@ const DisplayRemoteData: React.FC<{ id: string }> = ({ id }) => {
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;
-  return <div>RemoteData:{result.data.title}</div>;
+  return <div>RemoteData: {result.data.title}</div>;
 };
 
 export default DisplayRemoteData;

--- a/examples/06_progress/src/DelayedData.tsx
+++ b/examples/06_progress/src/DelayedData.tsx
@@ -14,11 +14,11 @@ const renderHello5 = () => <span>Hello5</span>;
 
 const RemoteData: React.FC = () => {
   const asyncTasks = [
-    useAsyncTaskTimeout(renderHello1, 1000, [renderHello1]),
-    useAsyncTaskTimeout(renderHello2, 2000, [renderHello2]),
-    useAsyncTaskTimeout(renderHello3, 3000, [renderHello3]),
-    useAsyncTaskTimeout(renderHello4, 4000, [renderHello4]),
-    useAsyncTaskTimeout(renderHello5, 5000, [renderHello5]),
+    useAsyncTaskTimeout(renderHello1, 1000),
+    useAsyncTaskTimeout(renderHello2, 2000),
+    useAsyncTaskTimeout(renderHello3, 3000),
+    useAsyncTaskTimeout(renderHello4, 4000),
+    useAsyncTaskTimeout(renderHello5, 5000),
   ];
   const combinedTask = useAsyncCombineAll(...asyncTasks);
   useAsyncRun(combinedTask);
@@ -35,11 +35,7 @@ const RemoteData: React.FC = () => {
       RemoteData:
       {asyncTasks.map((task, index) => (
         task.result && (
-          <div>
-            {index}
-            :
-            {task.result}
-          </div>
+          <div>{index}: {task.result}</div>
         )
       ))}
     </div>

--- a/examples/07_race/src/DelayedData.tsx
+++ b/examples/07_race/src/DelayedData.tsx
@@ -14,11 +14,11 @@ const renderHello5 = () => <span>Hello5</span>;
 
 const RemoteData: React.FC = () => {
   const asyncTasks = [
-    useAsyncTaskTimeout(renderHello1, 1000, [renderHello1]),
-    useAsyncTaskTimeout(renderHello2, 2000, [renderHello2]),
-    useAsyncTaskTimeout(renderHello3, 3000, [renderHello3]),
-    useAsyncTaskTimeout(renderHello4, 4000, [renderHello4]),
-    useAsyncTaskTimeout(renderHello5, 5000, [renderHello5]),
+    useAsyncTaskTimeout(renderHello1, 1000),
+    useAsyncTaskTimeout(renderHello2, 2000),
+    useAsyncTaskTimeout(renderHello3, 3000),
+    useAsyncTaskTimeout(renderHello4, 4000),
+    useAsyncTaskTimeout(renderHello5, 5000),
   ];
   const combinedTask = useAsyncCombineRace(...asyncTasks);
   useAsyncRun(combinedTask);
@@ -34,7 +34,7 @@ const RemoteData: React.FC = () => {
     <div>
       RemoteData:
       {asyncTasks.map((task, index) => (
-        task.result && <div>{index}:{task.result}</div>
+        task.result && <div>{index}: {task.result}</div>
       ))}
     </div>
   );

--- a/examples/08_wasm/src/CalcFib.tsx
+++ b/examples/08_wasm/src/CalcFib.tsx
@@ -9,7 +9,7 @@ type Result = {
 };
 
 const Err: React.SFC<{ error: Error }> = ({ error }) => (
-  <div>Error:{error.name}{' '}{error.message}</div>
+  <div>Error: {error.name} {error.message}</div>
 );
 
 const Loading: React.SFC<{ abort: () => void }> = ({ abort }) => (
@@ -30,7 +30,7 @@ const CalcFib: React.FC<{ count: number }> = ({ count }) => {
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;
-  return <div>Fib:{result.exports.fib(count)}</div>;
+  return <div>Fib: {result.exports.fib(count)}</div>;
 };
 
 export default CalcFib;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9663,6 +9663,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-memo-one": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.0.tgz",
+      "integrity": "sha512-mGmKaX2vauOWpFas4mGXj65JXkueLcca3OsT2iBKwB/Nl7NQeABIzBYq/HzVkFvnHXsf/S59DNN5UEOU+Bp1uw=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "fetch"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "use-memo-one": "^1.1.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,3 @@
-export type DependencyList = unknown[];
-
 export type AsyncTask<Result> = {
   started: boolean;
   pending: boolean;
@@ -11,7 +9,6 @@ export type AsyncTask<Result> = {
 
 export type UseAsyncTask = <Result>(
   func: (c: AbortController) => Promise<Result>,
-  deps: DependencyList,
 ) => AsyncTask<Result>;
 
 type Falsy = false | 0 | '' | null | undefined;
@@ -37,7 +34,6 @@ export const useAsyncCombineRace: UseAsyncCombine;
 export type UseAsyncTaskTimeout = <Result>(
   func: () => Result,
   delay: number,
-  deps: DependencyList,
 ) => AsyncTask<Result>;
 
 export const useAsyncTaskTimeout: UseAsyncTaskTimeout;
@@ -45,8 +41,7 @@ export const useAsyncTaskTimeout: UseAsyncTaskTimeout;
 // delay task
 
 export type UseAsyncTaskDelay = (
-  milliSeconds: number,
-  deps: DependencyList,
+  delay: number | (() => number),
 ) => AsyncTask<true>;
 
 export const useAsyncTaskDelay: UseAsyncTaskDelay;
@@ -71,7 +66,6 @@ export type UseAsyncTaskAxios = <
 >(
   axios: AxiosInstance,
   config: AxiosRequestConfig,
-  deps: DependencyList,
 ) => AsyncTask<Result>;
 
 export const useAsyncTaskAxios: UseAsyncTaskAxios;

--- a/src/use-async-combine-all.js
+++ b/src/use-async-combine-all.js
@@ -1,19 +1,26 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 
 export const useAsyncCombineAll = (...asyncTasks) => {
-  const task = useAsyncTask(async (abortController) => {
-    abortController.signal.addEventListener('abort', () => {
-      asyncTasks.forEach((asyncTask) => {
-        if (asyncTask.abort) {
-          asyncTask.abort();
-        }
+  const task = useAsyncTask(useCallback(
+    async (abortController) => {
+      abortController.signal.addEventListener('abort', () => {
+        asyncTasks.forEach((asyncTask) => {
+          if (asyncTask.abort) {
+            asyncTask.abort();
+          }
+        });
       });
-    });
-    asyncTasks.forEach((asyncTask) => {
-      if (!asyncTask.start) throw new Error('no asyncTask.start');
-      asyncTask.start();
-    });
-  }, asyncTasks.map(({ start }) => start));
+      asyncTasks.forEach((asyncTask) => {
+        if (!asyncTask.start) throw new Error('no asyncTask.start');
+        asyncTask.start();
+      });
+    },
+    // TODO Do we have a better way?
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    asyncTasks.map(({ start }) => start),
+  ));
   return {
     ...task,
     pending: asyncTasks.some(({ pending }) => pending),

--- a/src/use-async-task-axios.js
+++ b/src/use-async-task-axios.js
@@ -1,7 +1,9 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 import { useAsyncRun } from './use-async-run';
 
-export const useAsyncTaskAxios = (axios, config, deps) => useAsyncTask(
+export const useAsyncTaskAxios = (axios, config) => useAsyncTask(useCallback(
   (abortController) => {
     const source = axios.CancelToken.source();
     abortController.signal.addEventListener('abort', () => {
@@ -12,8 +14,8 @@ export const useAsyncTaskAxios = (axios, config, deps) => useAsyncTask(
       cancelToken: source.token,
     });
   },
-  deps,
-);
+  [axios, config],
+));
 
 export const useAxios = (...args) => {
   const asyncTask = useAsyncTaskAxios(...args);

--- a/src/use-async-task-delay.js
+++ b/src/use-async-task-delay.js
@@ -1,3 +1,5 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 
 const createAbortError = (message) => {
@@ -10,15 +12,15 @@ const createAbortError = (message) => {
   }
 };
 
-export const useAsyncTaskDelay = (milliSeconds, deps) => useAsyncTask(
+export const useAsyncTaskDelay = delay => useAsyncTask(useCallback(
   abortController => new Promise((resolve, reject) => {
     const id = setTimeout(() => {
       resolve(true);
-    }, milliSeconds);
+    }, typeof delay === 'function' ? delay() : delay);
     abortController.signal.addEventListener('abort', () => {
       clearTimeout(id);
       reject(createAbortError('timer aborted'));
     });
   }),
-  deps,
-);
+  [delay],
+));

--- a/src/use-async-task-fetch.js
+++ b/src/use-async-task-fetch.js
@@ -1,3 +1,5 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 import { useAsyncRun } from './use-async-run';
 
@@ -14,7 +16,7 @@ export const useAsyncTaskFetch = (
   input,
   init = defaultInit,
   readBody = defaultReadBody,
-) => useAsyncTask(
+) => useAsyncTask(useCallback(
   async (abortController) => {
     const response = await fetch(input, {
       signal: abortController.signal,
@@ -27,7 +29,7 @@ export const useAsyncTaskFetch = (
     return body;
   },
   [input, init, readBody],
-);
+));
 
 export const useFetch = (...args) => {
   const asyncTask = useAsyncTaskFetch(...args);

--- a/src/use-async-task-timeout.js
+++ b/src/use-async-task-timeout.js
@@ -1,3 +1,5 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 
 const createAbortError = (message) => {
@@ -10,7 +12,7 @@ const createAbortError = (message) => {
   }
 };
 
-export const useAsyncTaskTimeout = (func, delay, deps) => useAsyncTask(
+export const useAsyncTaskTimeout = (func, delay) => useAsyncTask(useCallback(
   abortController => new Promise((resolve, reject) => {
     const id = setTimeout(() => {
       resolve(func());
@@ -20,5 +22,5 @@ export const useAsyncTaskTimeout = (func, delay, deps) => useAsyncTask(
       reject(createAbortError('timer aborted'));
     });
   }),
-  deps,
-);
+  [func, delay],
+));

--- a/src/use-async-task-wasm.js
+++ b/src/use-async-task-wasm.js
@@ -1,3 +1,5 @@
+import { useCallbackOne as useCallback } from 'use-memo-one';
+
 import { useAsyncTask } from './use-async-task';
 import { useAsyncRun } from './use-async-run';
 
@@ -6,7 +8,7 @@ const defaultImportObject = {};
 export const useAsyncTaskWasm = (
   input,
   importObject = defaultImportObject,
-) => useAsyncTask(
+) => useAsyncTask(useCallback(
   async (abortController) => {
     const response = await fetch(input, {
       signal: abortController.signal,
@@ -18,7 +20,7 @@ export const useAsyncTaskWasm = (
     return results.instance;
   },
   [input, importObject],
-);
+));
 
 export const useWasm = (...args) => {
   const asyncTask = useAsyncTaskWasm(...args);

--- a/src/use-async-task.js
+++ b/src/use-async-task.js
@@ -44,7 +44,7 @@ const reducer = (state, action) => {
   }
 };
 
-export const useAsyncTask = (func, deps) => {
+export const useAsyncTask = (func) => {
   const [state, dispatch] = useReducer(reducer, initialState);
   useEffect(() => {
     let dispatchSafe = action => dispatch(action);
@@ -71,6 +71,6 @@ export const useAsyncTask = (func, deps) => {
       dispatch({ type: 'init' });
     };
     return cleanup;
-  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [func]);
   return state;
 };


### PR DESCRIPTION
It seems like the idiomatic React prefers ensuring argument referential equality on the caller end, to accepting `deps` in hooks.
This is going to be a big breaking change. (Actually, it's been changing back and forth.)

I made a choice to depend on use-memo-one by @alexreardon .

Feedback welcomed.