### PR TITLE
Custom args and reusable tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Changed
-- Support custom args and reusable tasks (#17)
+- Support custom args and reusable tasks (#18)
 
 ## [3.0.0] - 2019-07-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Support custom args and reusable tasks (#17)
 
 ## [3.0.0] - 2019-07-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ This function is to create a new async task.
 The first argument `func` is a function with an argument
 which is AbortController. This function returns a promise,
 but the function is responsible to cancel the promise by AbortController.
+If `func` receives the second or rest arguments, those can be passed by
+`useAsyncRun(task, ...args)` or `task.start(...args)`.
 
 When `func` is referentially changed, a new async task will be created.
 
@@ -151,10 +153,15 @@ The state of the task can be destructured like the following:
 const { pending, error, result } = task;
 ```
 
+When a task is created, it's not started.
+To run a task, either
+call `useAsyncRun(task, [...args])` in render, or
+call `task.start([...args])` in callback.
+
 #### useAsyncRun
 
 ```javascript
-useAsyncRun(task);
+useAsyncRun(task, ...args);
 ```
 
 This function is to run an async task.
@@ -168,6 +175,10 @@ it won't run any tasks. Hence, it's possible to control the timing by:
 ```javascript
 useAsyncRun(ready && task);
 ```
+
+The second or rest arguments are optional.
+If they are provided, the referential equality matters,
+so useMemo/useMemoOne would be necessary.
 
 The return value of this function is `void`.
 You need to keep using `task` to get the state of the task.

--- a/dist/use-async-combine-all.js
+++ b/dist/use-async-combine-all.js
@@ -66,13 +66,11 @@ var useAsyncCombineAll = function useAsyncCombineAll() {
             case 0:
               abortController.signal.addEventListener('abort', function () {
                 asyncTasks.forEach(function (asyncTask) {
-                  if (asyncTask.abort) {
-                    asyncTask.abort();
-                  }
+                  asyncTask.abort();
                 });
-              });
+              }); // start everything
+
               asyncTasks.forEach(function (asyncTask) {
-                if (!asyncTask.start) throw new Error('no asyncTask.start');
                 asyncTask.start();
               });
 
@@ -87,8 +85,7 @@ var useAsyncCombineAll = function useAsyncCombineAll() {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), // TODO Do we have a better way?
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }(), // eslint-disable-next-line react-hooks/exhaustive-deps
   asyncTasks.map(function (_ref2) {
     var start = _ref2.start;
     return start;

--- a/dist/use-async-combine-all.js
+++ b/dist/use-async-combine-all.js
@@ -1,9 +1,5 @@
 "use strict";
 
-require("core-js/modules/es.symbol");
-
-require("core-js/modules/es.array.filter");
-
 require("core-js/modules/es.array.find");
 
 require("core-js/modules/es.array.for-each");
@@ -12,15 +8,7 @@ require("core-js/modules/es.array.map");
 
 require("core-js/modules/es.array.some");
 
-require("core-js/modules/es.object.define-properties");
-
 require("core-js/modules/es.object.define-property");
-
-require("core-js/modules/es.object.get-own-property-descriptor");
-
-require("core-js/modules/es.object.get-own-property-descriptors");
-
-require("core-js/modules/es.object.keys");
 
 require("core-js/modules/es.object.to-string");
 
@@ -39,15 +27,16 @@ var _useMemoOne = require("use-memo-one");
 
 var _useAsyncTask = require("./use-async-task");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+var useMemoList = function useMemoList(items) {
+  return (0, _useMemoOne.useMemoOne)(function () {
+    return items;
+  }, items);
+};
 
 var useAsyncCombineAll = function useAsyncCombineAll() {
   for (var _len = arguments.length, asyncTasks = new Array(_len), _key = 0; _key < _len; _key++) {
@@ -90,24 +79,33 @@ var useAsyncCombineAll = function useAsyncCombineAll() {
     var start = _ref2.start;
     return start;
   })));
-  return _objectSpread({}, task, {
-    pending: asyncTasks.some(function (_ref3) {
-      var pending = _ref3.pending;
-      return pending;
-    }),
-    error: asyncTasks.find(function (_ref4) {
-      var error = _ref4.error;
-      return error;
-    }),
-    errorAll: asyncTasks.map(function (_ref5) {
-      var error = _ref5.error;
-      return error;
-    }),
-    result: asyncTasks.map(function (_ref6) {
-      var result = _ref6.result;
-      return result;
-    })
+  var taskPending = asyncTasks.some(function (_ref3) {
+    var pending = _ref3.pending;
+    return pending;
   });
+  var taskError = asyncTasks.find(function (_ref4) {
+    var error = _ref4.error;
+    return error;
+  });
+  var taskErrorAll = useMemoList(asyncTasks.map(function (_ref5) {
+    var error = _ref5.error;
+    return error;
+  }));
+  var taskResult = useMemoList(asyncTasks.map(function (_ref6) {
+    var result = _ref6.result;
+    return result;
+  }));
+  return (0, _useMemoOne.useMemoOne)(function () {
+    return {
+      start: task.start,
+      abort: task.abort,
+      started: task.started,
+      pending: taskPending,
+      error: taskError,
+      errorAll: taskErrorAll,
+      result: taskResult
+    };
+  }, [task.start, task.abort, task.started, taskPending, taskError, taskErrorAll, taskResult]);
 };
 
 exports.useAsyncCombineAll = useAsyncCombineAll;

--- a/dist/use-async-combine-race.js
+++ b/dist/use-async-combine-race.js
@@ -1,32 +1,10 @@
 "use strict";
 
-require("core-js/modules/es.symbol");
-
-require("core-js/modules/es.array.filter");
-
-require("core-js/modules/es.array.find");
-
 require("core-js/modules/es.array.find-index");
 
 require("core-js/modules/es.array.for-each");
 
-require("core-js/modules/es.array.map");
-
-require("core-js/modules/es.array.some");
-
-require("core-js/modules/es.object.define-properties");
-
 require("core-js/modules/es.object.define-property");
-
-require("core-js/modules/es.object.get-own-property-descriptor");
-
-require("core-js/modules/es.object.get-own-property-descriptors");
-
-require("core-js/modules/es.object.keys");
-
-require("core-js/modules/es.object.to-string");
-
-require("core-js/modules/es.promise");
 
 require("core-js/modules/web.dom-collections.for-each");
 
@@ -35,121 +13,32 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.useAsyncCombineRace = void 0;
 
-require("regenerator-runtime/runtime");
-
 var _react = require("react");
 
-var _useMemoOne = require("use-memo-one");
-
-var _useAsyncTask = require("./use-async-task");
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
-
-function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+var _useAsyncCombineAll = require("./use-async-combine-all");
 
 var useAsyncCombineRace = function useAsyncCombineRace() {
   for (var _len = arguments.length, asyncTasks = new Array(_len), _key = 0; _key < _len; _key++) {
     asyncTasks[_key] = arguments[_key];
   }
 
-  var callback = (0, _react.useRef)(null);
+  var task = _useAsyncCombineAll.useAsyncCombineAll.apply(void 0, asyncTasks);
+
+  var finishedIndex = asyncTasks.findIndex(function (_ref) {
+    var pending = _ref.pending;
+    return !pending;
+  });
   (0, _react.useEffect)(function () {
-    if (callback.current) {
-      callback.current(asyncTasks);
+    // if there's one task finished, abort all the others
+    if (finishedIndex >= 0) {
+      asyncTasks.forEach(function (asyncTask, i) {
+        if (i !== finishedIndex) {
+          asyncTask.abort();
+        }
+      });
     }
   });
-  var task = (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
-  /*#__PURE__*/
-  function () {
-    var _ref = _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee(abortController) {
-      var stopOthers;
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              abortController.signal.addEventListener('abort', function () {
-                asyncTasks.forEach(function (asyncTask) {
-                  if (asyncTask.abort) {
-                    asyncTask.abort();
-                  }
-                });
-              });
-
-              stopOthers = function stopOthers(tasks) {
-                var index = tasks.findIndex(function (_ref2) {
-                  var pending = _ref2.pending;
-                  return !pending;
-                });
-
-                if (index >= 0) {
-                  tasks.forEach(function (asyncTask, i) {
-                    if (i !== index && asyncTask.abort) {
-                      asyncTask.abort();
-                    }
-                  });
-                }
-              };
-
-              callback.current = stopOthers;
-              asyncTasks.forEach(function (asyncTask) {
-                if (!asyncTask.start) throw new Error('no asyncTask.start');
-                asyncTask.start();
-              });
-
-            case 4:
-            case "end":
-              return _context.stop();
-          }
-        }
-      }, _callee);
-    }));
-
-    return function (_x) {
-      return _ref.apply(this, arguments);
-    };
-  }(), // TODO Do we have a better way?
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  asyncTasks.map(function (_ref3) {
-    var start = _ref3.start;
-    return start;
-  })));
-  (0, _react.useEffect)(function () {
-    var cleanup = function cleanup() {
-      callback.current = null;
-    };
-
-    return cleanup;
-  }, asyncTasks.map(function (_ref4) {
-    var start = _ref4.start;
-    return start;
-  })); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return _objectSpread({}, task, {
-    pending: asyncTasks.some(function (_ref5) {
-      var pending = _ref5.pending;
-      return pending;
-    }),
-    error: asyncTasks.find(function (_ref6) {
-      var error = _ref6.error;
-      return error;
-    }),
-    errorAll: asyncTasks.map(function (_ref7) {
-      var error = _ref7.error;
-      return error;
-    }),
-    result: asyncTasks.map(function (_ref8) {
-      var result = _ref8.result;
-      return result;
-    })
-  });
+  return task;
 };
 
 exports.useAsyncCombineRace = useAsyncCombineRace;

--- a/dist/use-async-combine-seq.js
+++ b/dist/use-async-combine-seq.js
@@ -58,58 +58,25 @@ var useAsyncCombineSeq = function useAsyncCombineSeq() {
     asyncTasks[_key] = arguments[_key];
   }
 
-  var callback = (0, _react.useRef)(null);
-  (0, _react.useEffect)(function () {
-    if (callback.current) {
-      callback.current(asyncTasks);
-    }
-  });
   var task = (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(
   /*#__PURE__*/
   function () {
     var _ref = _asyncToGenerator(
     /*#__PURE__*/
     regeneratorRuntime.mark(function _callee(abortController) {
-      var startNext;
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
               abortController.signal.addEventListener('abort', function () {
                 asyncTasks.forEach(function (asyncTask) {
-                  if (asyncTask.abort) {
-                    asyncTask.abort();
-                  }
+                  asyncTask.abort();
                 });
-              });
+              }); // start the first one
 
-              startNext = function startNext(tasks) {
-                var index = tasks.findIndex(function (_ref2) {
-                  var started = _ref2.started;
-                  return !started;
-                });
-                var prevTask = tasks[index - 1];
-                var nextTask = tasks[index];
-
-                if (nextTask && prevTask && !prevTask.pending && !prevTask.error) {
-                  if (!nextTask.start) throw new Error('no asyncTask.start');
-                  nextTask.start();
-                }
-              };
-
-              callback.current = startNext;
-
-              if (asyncTasks[0].start) {
-                _context.next = 5;
-                break;
-              }
-
-              throw new Error('no asyncTask.start');
-
-            case 5:
               asyncTasks[0].start();
 
-            case 6:
+            case 2:
             case "end":
               return _context.stop();
           }
@@ -120,38 +87,39 @@ var useAsyncCombineSeq = function useAsyncCombineSeq() {
     return function (_x) {
       return _ref.apply(this, arguments);
     };
-  }(), // TODO Do we have a better way?
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  asyncTasks.map(function (_ref3) {
-    var start = _ref3.start;
+  }(), // eslint-disable-next-line react-hooks/exhaustive-deps
+  asyncTasks.map(function (_ref2) {
+    var start = _ref2.start;
     return start;
   })));
   (0, _react.useEffect)(function () {
-    var cleanup = function cleanup() {
-      callback.current = null;
-    };
+    // if prev task is finished, start next task
+    var index = asyncTasks.findIndex(function (_ref3) {
+      var started = _ref3.started;
+      return !started;
+    });
+    var prevTask = asyncTasks[index - 1];
+    var nextTask = asyncTasks[index];
 
-    return cleanup;
-  }, asyncTasks.map(function (_ref4) {
-    var start = _ref4.start;
-    return start;
-  })); // eslint-disable-line react-hooks/exhaustive-deps
-
+    if (nextTask && prevTask && !prevTask.pending && !prevTask.error) {
+      nextTask.start();
+    }
+  });
   return _objectSpread({}, task, {
-    pending: asyncTasks.some(function (_ref5) {
-      var pending = _ref5.pending;
+    pending: asyncTasks.some(function (_ref4) {
+      var pending = _ref4.pending;
       return pending;
     }),
-    error: asyncTasks.find(function (_ref6) {
+    error: asyncTasks.find(function (_ref5) {
+      var error = _ref5.error;
+      return error;
+    }),
+    errorAll: asyncTasks.map(function (_ref6) {
       var error = _ref6.error;
       return error;
     }),
-    errorAll: asyncTasks.map(function (_ref7) {
-      var error = _ref7.error;
-      return error;
-    }),
-    result: asyncTasks.map(function (_ref8) {
-      var result = _ref8.result;
+    result: asyncTasks.map(function (_ref7) {
+      var result = _ref7.result;
       return result;
     })
   });

--- a/dist/use-async-combine-seq.js
+++ b/dist/use-async-combine-seq.js
@@ -1,9 +1,5 @@
 "use strict";
 
-require("core-js/modules/es.symbol");
-
-require("core-js/modules/es.array.filter");
-
 require("core-js/modules/es.array.find");
 
 require("core-js/modules/es.array.find-index");
@@ -14,15 +10,7 @@ require("core-js/modules/es.array.map");
 
 require("core-js/modules/es.array.some");
 
-require("core-js/modules/es.object.define-properties");
-
 require("core-js/modules/es.object.define-property");
-
-require("core-js/modules/es.object.get-own-property-descriptor");
-
-require("core-js/modules/es.object.get-own-property-descriptors");
-
-require("core-js/modules/es.object.keys");
 
 require("core-js/modules/es.object.to-string");
 
@@ -43,15 +31,16 @@ var _useMemoOne = require("use-memo-one");
 
 var _useAsyncTask = require("./use-async-task");
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+var useMemoList = function useMemoList(items) {
+  return (0, _useMemoOne.useMemoOne)(function () {
+    return items;
+  }, items);
+};
 
 var useAsyncCombineSeq = function useAsyncCombineSeq() {
   for (var _len = arguments.length, asyncTasks = new Array(_len), _key = 0; _key < _len; _key++) {
@@ -105,24 +94,33 @@ var useAsyncCombineSeq = function useAsyncCombineSeq() {
       nextTask.start();
     }
   });
-  return _objectSpread({}, task, {
-    pending: asyncTasks.some(function (_ref4) {
-      var pending = _ref4.pending;
-      return pending;
-    }),
-    error: asyncTasks.find(function (_ref5) {
-      var error = _ref5.error;
-      return error;
-    }),
-    errorAll: asyncTasks.map(function (_ref6) {
-      var error = _ref6.error;
-      return error;
-    }),
-    result: asyncTasks.map(function (_ref7) {
-      var result = _ref7.result;
-      return result;
-    })
+  var taskPending = asyncTasks.some(function (_ref4) {
+    var pending = _ref4.pending;
+    return pending;
   });
+  var taskError = asyncTasks.find(function (_ref5) {
+    var error = _ref5.error;
+    return error;
+  });
+  var taskErrorAll = useMemoList(asyncTasks.map(function (_ref6) {
+    var error = _ref6.error;
+    return error;
+  }));
+  var taskResult = useMemoList(asyncTasks.map(function (_ref7) {
+    var result = _ref7.result;
+    return result;
+  }));
+  return (0, _useMemoOne.useMemoOne)(function () {
+    return {
+      start: task.start,
+      abort: task.abort,
+      started: task.started,
+      pending: taskPending,
+      error: taskError,
+      errorAll: taskErrorAll,
+      result: taskResult
+    };
+  }, [task.start, task.abort, task.started, taskPending, taskError, taskErrorAll, taskResult]);
 };
 
 exports.useAsyncCombineSeq = useAsyncCombineSeq;

--- a/dist/use-async-run.js
+++ b/dist/use-async-run.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require("core-js/modules/es.array.concat");
+
 require("core-js/modules/es.object.define-property");
 
 Object.defineProperty(exports, "__esModule", {
@@ -10,18 +12,18 @@ exports.useAsyncRun = void 0;
 var _react = require("react");
 
 var useAsyncRun = function useAsyncRun(asyncTask) {
-  var start = asyncTask && asyncTask.start;
-  var abort = asyncTask && asyncTask.abort;
+  for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    args[_key - 1] = arguments[_key];
+  }
+
+  var start = asyncTask.start,
+      abort = asyncTask.abort;
   (0, _react.useEffect)(function () {
-    if (start) {
-      start();
-    }
-  }, [start]);
+    start.apply(void 0, args); // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asyncTask.start].concat(args));
   (0, _react.useEffect)(function () {
     var cleanup = function cleanup() {
-      if (abort) {
-        abort();
-      }
+      abort();
     };
 
     return cleanup;

--- a/dist/use-async-task-axios.js
+++ b/dist/use-async-task-axios.js
@@ -36,12 +36,12 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var useAsyncTaskAxios = function useAsyncTaskAxios(axios, config) {
-  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController, configOverride) {
     var source = axios.CancelToken.source();
     abortController.signal.addEventListener('abort', function () {
       source.cancel('canceled');
     });
-    return axios(_objectSpread({}, config, {
+    return axios(_objectSpread({}, config, {}, configOverride, {
       cancelToken: source.token
     }));
   }, [axios, config]));

--- a/dist/use-async-task-delay.js
+++ b/dist/use-async-task-delay.js
@@ -30,11 +30,12 @@ var createAbortError = function createAbortError(message) {
 };
 
 var useAsyncTaskDelay = function useAsyncTaskDelay(delay) {
-  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController, delayOverride) {
     return new Promise(function (resolve, reject) {
+      var delayToUse = delayOverride || delay;
       var id = setTimeout(function () {
         resolve(true);
-      }, typeof delay === 'function' ? delay() : delay);
+      }, typeof delayToUse === 'function' ? delayToUse() : delayToUse);
       abortController.signal.addEventListener('abort', function () {
         clearTimeout(id);
         reject(createAbortError('timer aborted'));

--- a/dist/use-async-task-fetch.js
+++ b/dist/use-async-task-fetch.js
@@ -67,16 +67,16 @@ var useAsyncTaskFetch = function useAsyncTaskFetch(input) {
   function () {
     var _ref = _asyncToGenerator(
     /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee(abortController) {
+    regeneratorRuntime.mark(function _callee(abortController, inputOverride, initOverride) {
       var response, body;
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch(input, _objectSpread({
+              return fetch(inputOverride || input, _objectSpread({}, init, {}, initOverride, {
                 signal: abortController.signal
-              }, init));
+              }));
 
             case 2:
               response = _context.sent;
@@ -104,7 +104,7 @@ var useAsyncTaskFetch = function useAsyncTaskFetch(input) {
       }, _callee);
     }));
 
-    return function (_x) {
+    return function (_x, _x2, _x3) {
       return _ref.apply(this, arguments);
     };
   }(), [input, init, readBody]));

--- a/dist/use-async-task-timeout.js
+++ b/dist/use-async-task-timeout.js
@@ -30,11 +30,12 @@ var createAbortError = function createAbortError(message) {
 };
 
 var useAsyncTaskTimeout = function useAsyncTaskTimeout(func, delay) {
-  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController) {
+  return (0, _useAsyncTask.useAsyncTask)((0, _useMemoOne.useCallbackOne)(function (abortController, delayOverride) {
     return new Promise(function (resolve, reject) {
+      var delayToUse = delayOverride || delay;
       var id = setTimeout(function () {
         resolve(func());
-      }, delay);
+      }, delayToUse);
       abortController.signal.addEventListener('abort', function () {
         clearTimeout(id);
         reject(createAbortError('timer aborted'));

--- a/dist/use-async-task-wasm.js
+++ b/dist/use-async-task-wasm.js
@@ -1,10 +1,36 @@
 "use strict";
 
+require("core-js/modules/es.symbol");
+
+require("core-js/modules/es.symbol.description");
+
+require("core-js/modules/es.symbol.iterator");
+
+require("core-js/modules/es.array.filter");
+
+require("core-js/modules/es.array.for-each");
+
+require("core-js/modules/es.array.iterator");
+
+require("core-js/modules/es.object.define-properties");
+
 require("core-js/modules/es.object.define-property");
+
+require("core-js/modules/es.object.get-own-property-descriptor");
+
+require("core-js/modules/es.object.get-own-property-descriptors");
+
+require("core-js/modules/es.object.keys");
 
 require("core-js/modules/es.object.to-string");
 
 require("core-js/modules/es.promise");
+
+require("core-js/modules/es.string.iterator");
+
+require("core-js/modules/web.dom-collections.for-each");
+
+require("core-js/modules/web.dom-collections.iterator");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -19,6 +45,14 @@ var _useAsyncTask = require("./use-async-task");
 
 var _useAsyncRun = require("./use-async-run");
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
@@ -32,36 +66,37 @@ var useAsyncTaskWasm = function useAsyncTaskWasm(input) {
   function () {
     var _ref = _asyncToGenerator(
     /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee(abortController) {
-      var response, results;
+    regeneratorRuntime.mark(function _callee(abortController, inputOverride) {
+      var inputToUse, response, results;
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
-              _context.next = 2;
-              return fetch(input, {
+              inputToUse = _typeof(input) === 'object' && _typeof(inputOverride) === 'object' ? _objectSpread({}, input, {}, inputOverride) : inputOverride || input;
+              _context.next = 3;
+              return fetch(inputToUse, {
                 signal: abortController.signal
               });
 
-            case 2:
+            case 3:
               response = _context.sent;
 
               if (response.ok) {
-                _context.next = 5;
+                _context.next = 6;
                 break;
               }
 
               throw new Error(response.statusText);
 
-            case 5:
-              _context.next = 7;
+            case 6:
+              _context.next = 8;
               return WebAssembly.instantiateStreaming(response, importObject);
 
-            case 7:
+            case 8:
               results = _context.sent;
               return _context.abrupt("return", results.instance);
 
-            case 9:
+            case 10:
             case "end":
               return _context.stop();
           }
@@ -69,7 +104,7 @@ var useAsyncTaskWasm = function useAsyncTaskWasm(input) {
       }, _callee);
     }));
 
-    return function (_x) {
+    return function (_x, _x2) {
       return _ref.apply(this, arguments);
     };
   }(), [input, importObject]));

--- a/dist/use-async-task.js
+++ b/dist/use-async-task.js
@@ -1,40 +1,12 @@
 "use strict";
 
-require("core-js/modules/es.symbol");
-
-require("core-js/modules/es.symbol.description");
-
-require("core-js/modules/es.symbol.iterator");
-
 require("core-js/modules/es.array.concat");
 
-require("core-js/modules/es.array.filter");
-
-require("core-js/modules/es.array.for-each");
-
-require("core-js/modules/es.array.is-array");
-
-require("core-js/modules/es.array.iterator");
-
-require("core-js/modules/es.object.define-properties");
-
 require("core-js/modules/es.object.define-property");
-
-require("core-js/modules/es.object.get-own-property-descriptor");
-
-require("core-js/modules/es.object.get-own-property-descriptors");
-
-require("core-js/modules/es.object.keys");
 
 require("core-js/modules/es.object.to-string");
 
 require("core-js/modules/es.promise");
-
-require("core-js/modules/es.string.iterator");
-
-require("core-js/modules/web.dom-collections.for-each");
-
-require("core-js/modules/web.dom-collections.iterator");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -47,186 +19,123 @@ var _react = require("react");
 
 var _useMemoOne = require("use-memo-one");
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
-
-function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-var useIsomorphicLayoutEffect = typeof window !== 'undefined' ? _react.useLayoutEffect : _react.useEffect;
+var forcedReducer = function forcedReducer(state) {
+  return state + 1;
+};
 
-var createTask = function createTask(func, dispatchRef) {
-  var abortController = null;
+var useForceUpdate = function useForceUpdate() {
+  return (0, _react.useReducer)(forcedReducer, 0)[1];
+};
 
-  var abort = function abort() {
-    if (abortController) {
-      abortController.abort();
-      abortController = null;
-    }
-  };
+var createTask = function createTask(func, forceUpdateRef) {
+  var task = {
+    abortController: null,
+    start: function () {
+      var _start = _asyncToGenerator(
+      /*#__PURE__*/
+      regeneratorRuntime.mark(function _callee() {
+        var _len,
+            args,
+            _key,
+            _args = arguments;
 
-  var start =
-  /*#__PURE__*/
-  function () {
-    var _ref = _asyncToGenerator(
-    /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
-      var _len,
-          args,
-          _key,
-          result,
-          _args = arguments;
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                task.abort();
+                task.abortController = new AbortController();
+                task.started = true;
+                task.pending = true;
+                task.error = null;
+                task.result = null;
+                forceUpdateRef.current(func);
+                _context.prev = 7;
 
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              abort();
-              abortController = new AbortController();
-              dispatchRef.current({
-                type: 'start',
-                func: func
-              });
-              _context.prev = 3;
+                for (_len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+                  args[_key] = _args[_key];
+                }
 
-              for (_len = _args.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-                args[_key] = _args[_key];
-              }
+                _context.next = 11;
+                return func.apply(void 0, [task.abortController].concat(args));
 
-              _context.next = 7;
-              return func.apply(void 0, [abortController].concat(args));
+              case 11:
+                task.result = _context.sent;
+                _context.next = 17;
+                break;
 
-            case 7:
-              result = _context.sent;
-              dispatchRef.current({
-                type: 'result',
-                func: func,
-                result: result
-              });
-              _context.next = 14;
-              break;
+              case 14:
+                _context.prev = 14;
+                _context.t0 = _context["catch"](7);
+                task.error = _context.t0;
 
-            case 11:
-              _context.prev = 11;
-              _context.t0 = _context["catch"](3);
-              dispatchRef.current({
-                type: 'error',
-                func: func,
-                error: _context.t0
-              });
+              case 17:
+                task.pending = false;
+                forceUpdateRef.current(func);
 
-            case 14:
-            case "end":
-              return _context.stop();
+              case 19:
+              case "end":
+                return _context.stop();
+            }
           }
-        }
-      }, _callee, null, [[3, 11]]);
-    }));
+        }, _callee, null, [[7, 14]]);
+      }));
 
-    return function start() {
-      return _ref.apply(this, arguments);
-    };
-  }();
+      function start() {
+        return _start.apply(this, arguments);
+      }
 
-  return {
-    start: start,
-    abort: abort
+      return start;
+    }(),
+    abort: function abort() {
+      if (task.abortController) {
+        task.abortController.abort();
+        task.abortController = null;
+      }
+    },
+    started: false,
+    pending: true,
+    error: null,
+    result: null
   };
-};
-
-var initialState = {
-  func: null,
-  started: false,
-  pending: true,
-  error: null,
-  result: null
-};
-
-var reducer = function reducer(state, action) {
-  switch (action.type) {
-    case 'init':
-      return _objectSpread({}, initialState, {
-        func: action.func
-      });
-
-    case 'start':
-      if (state.func !== action.func) return state; // bail out
-
-      return _objectSpread({}, state, {
-        started: true,
-        pending: true,
-        error: null,
-        result: null
-      });
-
-    case 'result':
-      if (state.func !== action.func) return state; // bail out
-
-      return _objectSpread({}, state, {
-        pending: false,
-        result: action.result
-      });
-
-    case 'error':
-      if (state.func !== action.func) return state; // bail out
-
-      return _objectSpread({}, state, {
-        pending: false,
-        error: action.error
-      });
-
-    default:
-      throw new Error("unexpected action type: ".concat(action.type));
-  }
+  return task;
 };
 
 var useAsyncTask = function useAsyncTask(func) {
-  var _useReducer = (0, _react.useReducer)(reducer, initialState),
-      _useReducer2 = _slicedToArray(_useReducer, 2),
-      state = _useReducer2[0],
-      dispatch = _useReducer2[1];
-
-  var dispatchRef = (0, _react.useRef)(dispatch);
+  var forceUpdate = useForceUpdate();
+  var forceUpdateRef = (0, _react.useRef)(forceUpdate);
   var task = (0, _useMemoOne.useMemoOne)(function () {
-    return createTask(func, dispatchRef);
+    return createTask(func, forceUpdateRef);
   }, [func]);
-  useIsomorphicLayoutEffect(function () {
-    if (func !== state.func) {
-      dispatch({
-        type: 'init',
-        func: func
-      });
-    }
-  });
   (0, _react.useEffect)(function () {
+    forceUpdateRef.current = function (f) {
+      if (f === func) {
+        forceUpdate();
+      }
+    };
+
     var cleanup = function cleanup() {
-      dispatchRef.current = function () {
+      forceUpdateRef.current = function () {
         return null;
       };
     };
 
     return cleanup;
-  }, []);
-  return {
-    started: state.started,
-    pending: state.pending,
-    error: state.error,
-    result: state.result,
-    start: task.start,
-    abort: task.abort
-  };
+  }, [func, forceUpdate]);
+  return (0, _useMemoOne.useMemoOne)(function () {
+    return {
+      start: task.start,
+      abort: task.abort,
+      started: task.started,
+      pending: task.pending,
+      error: task.error,
+      result: task.result
+    };
+  }, [task.start, task.abort, task.started, task.pending, task.error, task.result]);
 };
 
 exports.useAsyncTask = useAsyncTask;

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -1,4 +1,4 @@
-import React, { StrictMode } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { useAsyncRun, useAsyncTaskTimeout } from 'react-hooks-async';
@@ -31,12 +31,10 @@ const DelayedMessage = ({ delay }) => {
 };
 
 const App = () => (
-  <StrictMode>
-    <div>
-      <DelayedMessage delay={3000} />
-      <DelayedMessage delay={1000} />
-    </div>
-  </StrictMode>
+  <div>
+    <DelayedMessage delay={3000} />
+    <DelayedMessage delay={1000} />
+  </div>
 );
 
 ReactDOM.unstable_createRoot(document.getElementById('app')).render(<App />);

--- a/examples/02_typescript/src/App.tsx
+++ b/examples/02_typescript/src/App.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
-import { useState, StrictMode } from 'react';
+import { useState } from 'react';
 
 import DisplayRemoteData from './DisplayRemoteData';
 
 const App = () => {
   const [id, setId] = useState(1);
   return (
-    <StrictMode>
-      <div>
-        id: {id}
-        <button type="button" onClick={() => setId(id + 1)}>Next</button>
-        <button type="button" onClick={() => setId(id - 1)}>Previous</button>
-        <DisplayRemoteData id={String(id)} />
-      </div>
-    </StrictMode>
+    <div>
+      id: {id}
+      <button type="button" onClick={() => setId(id + 1)}>Next</button>
+      <button type="button" onClick={() => setId(id - 1)}>Previous</button>
+      <DisplayRemoteData id={String(id)} />
+    </div>
   );
 };
 

--- a/examples/03_startbutton/src/App.tsx
+++ b/examples/03_startbutton/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, StrictMode } from 'react';
+import { useState } from 'react';
 
 import DisplayRemoteData from './DisplayRemoteData';
 import UserInfo from './UserInfo';
@@ -8,21 +8,19 @@ const App = () => {
   const [id, setId] = useState('1');
   const [id2, setId2] = useState('1');
   return (
-    <StrictMode>
+    <div>
       <div>
-        <div>
-          id:
-          <input value={id} onChange={e => setId(e.target.value)} />
-          {id && <DisplayRemoteData id={id} />}
-        </div>
-        <hr />
-        <div>
-          id:
-          <input value={id2} onChange={e => setId2(e.target.value)} />
-          {id2 && <UserInfo id={id2} />}
-        </div>
+        id:
+        <input value={id} onChange={e => setId(e.target.value)} />
+        {id && <DisplayRemoteData id={id} />}
       </div>
-    </StrictMode>
+      <hr />
+      <div>
+        id:
+        <input value={id2} onChange={e => setId2(e.target.value)} />
+        {id2 && <UserInfo id={id2} />}
+      </div>
+    </div>
   );
 };
 

--- a/examples/03_startbutton/src/DisplayRemoteData.tsx
+++ b/examples/03_startbutton/src/DisplayRemoteData.tsx
@@ -24,7 +24,7 @@ const DisplayRemoteData: React.FC<{ id: string }> = ({ id }) => {
     start,
     abort,
   } = asyncTask;
-  if (!started) return (start && <button type="button" onClick={start}>start</button>);
+  if (!started) return <button type="button" onClick={() => start()}>start</button>;
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;

--- a/examples/03_startbutton/src/UserInfo.tsx
+++ b/examples/03_startbutton/src/UserInfo.tsx
@@ -32,7 +32,7 @@ const UserInfo: React.FC<{ id: string }> = ({ id }) => {
     start,
     abort,
   } = asyncTask;
-  if (!started) return (start && <button type="button" onClick={start}>start</button>);
+  if (!started) return <button type="button" onClick={() => start()}>start</button>;
   if (error) return <Err error={error} />;
   if (pending) return <Loading abort={abort} />;
   if (!result) return <div>No result</div>;

--- a/examples/05_axios/src/App.tsx
+++ b/examples/05_axios/src/App.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
-import { useState, StrictMode } from 'react';
+import { useState } from 'react';
 
 import DisplayRemoteData from './DisplayRemoteData';
 
 const App = () => {
   const [id, setId] = useState(1);
   return (
-    <StrictMode>
-      <div>
-        id: {id}
-        <button type="button" onClick={() => setId(id + 1)}>Next</button>
-        <button type="button" onClick={() => setId(id - 1)}>Previous</button>
-        <DisplayRemoteData id={String(id)} />
-      </div>
-    </StrictMode>
+    <div>
+      id: {id}
+      <button type="button" onClick={() => setId(id + 1)}>Next</button>
+      <button type="button" onClick={() => setId(id - 1)}>Previous</button>
+      <DisplayRemoteData id={String(id)} />
+    </div>
   );
 };
 

--- a/examples/06_progress/src/App.tsx
+++ b/examples/06_progress/src/App.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
-import { StrictMode } from 'react';
 
 import DelayedData from './DelayedData';
 
 const App = () => (
-  <StrictMode>
-    <div>
-      <DelayedData />
-    </div>
-  </StrictMode>
+  <div>
+    <DelayedData />
+  </div>
 );
 
 export default App;

--- a/examples/07_race/src/App.tsx
+++ b/examples/07_race/src/App.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
-import { StrictMode } from 'react';
 
 import DelayedData from './DelayedData';
 
 const App = () => (
-  <StrictMode>
-    <div>
-      <DelayedData />
-    </div>
-  </StrictMode>
+  <div>
+    <DelayedData />
+  </div>
 );
 
 export default App;

--- a/examples/08_wasm/src/App.tsx
+++ b/examples/08_wasm/src/App.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
-import { useState, StrictMode } from 'react';
+import { useState } from 'react';
 
 import CalcFib from './CalcFib';
 
 const App = () => {
   const [count, setCount] = useState(1);
   return (
-    <StrictMode>
-      <div>
-        count: {count}
-        <button type="button" onClick={() => setCount(count + 1)}>+1</button>
-        <button type="button" onClick={() => setCount(count - 1)}>-1</button>
-        <CalcFib count={count} />
-      </div>
-    </StrictMode>
+    <div>
+      count: {count}
+      <button type="button" onClick={() => setCount(count + 1)}>+1</button>
+      <button type="button" onClick={() => setCount(count - 1)}>-1</button>
+      <CalcFib count={count} />
+    </div>
   );
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,10 @@
-export type AsyncTask<Result> = {
+export type AsyncTask<Result, Args extends unknown[] = unknown[]> = {
   started: boolean;
   pending: boolean;
   error: Error | null;
   result: Result | null;
-  start: () => void | null;
-  abort: () => void | null;
+  start: (...args: Args) => void;
+  abort: () => void;
 };
 
 export type UseAsyncTask = <Result>(
@@ -12,7 +12,10 @@ export type UseAsyncTask = <Result>(
 ) => AsyncTask<Result>;
 
 type Falsy = false | 0 | '' | null | undefined;
-export type UseAsyncRun = (t: AsyncTask<unknown> | Falsy) => void;
+export type UseAsyncRun = <Result, Args extends unknown[] = unknown[]>(
+  task: AsyncTask<Result> | Falsy,
+  ...args: Args,
+) => void;
 
 export type UseAsyncCombine = (
   ...ts: AsyncTask<unknown>[],

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,10 @@
 export type AsyncTask<Result, Args extends unknown[] = unknown[]> = {
+  start: (...args: Args) => void;
+  abort: () => void;
   started: boolean;
   pending: boolean;
   error: Error | null;
   result: Result | null;
-  start: (...args: Args) => void;
-  abort: () => void;
 };
 
 export type UseAsyncTask = <Result>(

--- a/src/use-async-combine-all.js
+++ b/src/use-async-combine-all.js
@@ -1,6 +1,12 @@
-import { useCallbackOne as useCallback } from 'use-memo-one';
+import {
+  useCallbackOne as useCallback,
+  useMemoOne as useMemo,
+} from 'use-memo-one';
 
 import { useAsyncTask } from './use-async-task';
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+const useMemoList = items => useMemo(() => items, items);
 
 export const useAsyncCombineAll = (...asyncTasks) => {
   const task = useAsyncTask(useCallback(
@@ -18,11 +24,25 @@ export const useAsyncCombineAll = (...asyncTasks) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     asyncTasks.map(({ start }) => start),
   ));
-  return {
-    ...task,
-    pending: asyncTasks.some(({ pending }) => pending),
-    error: asyncTasks.find(({ error }) => error),
-    errorAll: asyncTasks.map(({ error }) => error),
-    result: asyncTasks.map(({ result }) => result),
-  };
+  const taskPending = asyncTasks.some(({ pending }) => pending);
+  const taskError = asyncTasks.find(({ error }) => error);
+  const taskErrorAll = useMemoList(asyncTasks.map(({ error }) => error));
+  const taskResult = useMemoList(asyncTasks.map(({ result }) => result));
+  return useMemo(() => ({
+    start: task.start,
+    abort: task.abort,
+    started: task.started,
+    pending: taskPending,
+    error: taskError,
+    errorAll: taskErrorAll,
+    result: taskResult,
+  }), [
+    task.start,
+    task.abort,
+    task.started,
+    taskPending,
+    taskError,
+    taskErrorAll,
+    taskResult,
+  ]);
 };

--- a/src/use-async-combine-all.js
+++ b/src/use-async-combine-all.js
@@ -7,17 +7,14 @@ export const useAsyncCombineAll = (...asyncTasks) => {
     async (abortController) => {
       abortController.signal.addEventListener('abort', () => {
         asyncTasks.forEach((asyncTask) => {
-          if (asyncTask.abort) {
-            asyncTask.abort();
-          }
+          asyncTask.abort();
         });
       });
+      // start everything
       asyncTasks.forEach((asyncTask) => {
-        if (!asyncTask.start) throw new Error('no asyncTask.start');
         asyncTask.start();
       });
     },
-    // TODO Do we have a better way?
     // eslint-disable-next-line react-hooks/exhaustive-deps
     asyncTasks.map(({ start }) => start),
   ));

--- a/src/use-async-combine-race.js
+++ b/src/use-async-combine-race.js
@@ -44,7 +44,8 @@ export const useAsyncCombineRace = (...asyncTasks) => {
       callback.current = null;
     };
     return cleanup;
-  }, asyncTasks.map(({ start }) => start)); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, asyncTasks.map(({ start }) => start));
   return {
     ...task,
     pending: asyncTasks.some(({ pending }) => pending),

--- a/src/use-async-combine-seq.js
+++ b/src/use-async-combine-seq.js
@@ -1,7 +1,13 @@
 import { useEffect } from 'react';
-import { useCallbackOne as useCallback } from 'use-memo-one';
+import {
+  useCallbackOne as useCallback,
+  useMemoOne as useMemo,
+} from 'use-memo-one';
 
 import { useAsyncTask } from './use-async-task';
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+const useMemoList = items => useMemo(() => items, items);
 
 export const useAsyncCombineSeq = (...asyncTasks) => {
   const task = useAsyncTask(useCallback(
@@ -26,11 +32,25 @@ export const useAsyncCombineSeq = (...asyncTasks) => {
       nextTask.start();
     }
   });
-  return {
-    ...task,
-    pending: asyncTasks.some(({ pending }) => pending),
-    error: asyncTasks.find(({ error }) => error),
-    errorAll: asyncTasks.map(({ error }) => error),
-    result: asyncTasks.map(({ result }) => result),
-  };
+  const taskPending = asyncTasks.some(({ pending }) => pending);
+  const taskError = asyncTasks.find(({ error }) => error);
+  const taskErrorAll = useMemoList(asyncTasks.map(({ error }) => error));
+  const taskResult = useMemoList(asyncTasks.map(({ result }) => result));
+  return useMemo(() => ({
+    start: task.start,
+    abort: task.abort,
+    started: task.started,
+    pending: taskPending,
+    error: taskError,
+    errorAll: taskErrorAll,
+    result: taskResult,
+  }), [
+    task.start,
+    task.abort,
+    task.started,
+    taskPending,
+    taskError,
+    taskErrorAll,
+    taskResult,
+  ]);
 };

--- a/src/use-async-combine-seq.js
+++ b/src/use-async-combine-seq.js
@@ -41,7 +41,8 @@ export const useAsyncCombineSeq = (...asyncTasks) => {
       callback.current = null;
     };
     return cleanup;
-  }, asyncTasks.map(({ start }) => start)); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, asyncTasks.map(({ start }) => start));
   return {
     ...task,
     pending: asyncTasks.some(({ pending }) => pending),

--- a/src/use-async-combine-seq.js
+++ b/src/use-async-combine-seq.js
@@ -1,48 +1,31 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useCallbackOne as useCallback } from 'use-memo-one';
 
 import { useAsyncTask } from './use-async-task';
 
 export const useAsyncCombineSeq = (...asyncTasks) => {
-  const callback = useRef(null);
-  useEffect(() => {
-    if (callback.current) {
-      callback.current(asyncTasks);
-    }
-  });
   const task = useAsyncTask(useCallback(
     async (abortController) => {
       abortController.signal.addEventListener('abort', () => {
         asyncTasks.forEach((asyncTask) => {
-          if (asyncTask.abort) {
-            asyncTask.abort();
-          }
+          asyncTask.abort();
         });
       });
-      const startNext = (tasks) => {
-        const index = tasks.findIndex(({ started }) => !started);
-        const prevTask = tasks[index - 1];
-        const nextTask = tasks[index];
-        if (nextTask && prevTask && !prevTask.pending && !prevTask.error) {
-          if (!nextTask.start) throw new Error('no asyncTask.start');
-          nextTask.start();
-        }
-      };
-      callback.current = startNext;
-      if (!asyncTasks[0].start) throw new Error('no asyncTask.start');
+      // start the first one
       asyncTasks[0].start();
     },
-    // TODO Do we have a better way?
     // eslint-disable-next-line react-hooks/exhaustive-deps
     asyncTasks.map(({ start }) => start),
   ));
   useEffect(() => {
-    const cleanup = () => {
-      callback.current = null;
-    };
-    return cleanup;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, asyncTasks.map(({ start }) => start));
+    // if prev task is finished, start next task
+    const index = asyncTasks.findIndex(({ started }) => !started);
+    const prevTask = asyncTasks[index - 1];
+    const nextTask = asyncTasks[index];
+    if (nextTask && prevTask && !prevTask.pending && !prevTask.error) {
+      nextTask.start();
+    }
+  });
   return {
     ...task,
     pending: asyncTasks.some(({ pending }) => pending),

--- a/src/use-async-run.js
+++ b/src/use-async-run.js
@@ -1,19 +1,14 @@
 import { useEffect } from 'react';
 
 export const useAsyncRun = (asyncTask, ...args) => {
-  const start = asyncTask && asyncTask.start;
-  const abort = asyncTask && asyncTask.abort;
+  const { start, abort } = asyncTask;
   useEffect(() => {
-    if (start) {
-      start(...args);
-    }
+    start(...args);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [start, ...args]);
+  }, [asyncTask.start, ...args]);
   useEffect(() => {
     const cleanup = () => {
-      if (abort) {
-        abort();
-      }
+      abort();
     };
     return cleanup;
   }, [abort]);

--- a/src/use-async-run.js
+++ b/src/use-async-run.js
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
 
-export const useAsyncRun = (asyncTask) => {
+export const useAsyncRun = (asyncTask, ...args) => {
   const start = asyncTask && asyncTask.start;
   const abort = asyncTask && asyncTask.abort;
   useEffect(() => {
     if (start) {
-      start();
+      start(...args);
     }
-  }, [start]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [start, ...args]);
   useEffect(() => {
     const cleanup = () => {
       if (abort) {

--- a/src/use-async-task-axios.js
+++ b/src/use-async-task-axios.js
@@ -4,13 +4,14 @@ import { useAsyncTask } from './use-async-task';
 import { useAsyncRun } from './use-async-run';
 
 export const useAsyncTaskAxios = (axios, config) => useAsyncTask(useCallback(
-  (abortController) => {
+  (abortController, configOverride) => {
     const source = axios.CancelToken.source();
     abortController.signal.addEventListener('abort', () => {
       source.cancel('canceled');
     });
     return axios({
       ...config,
+      ...configOverride,
       cancelToken: source.token,
     });
   },

--- a/src/use-async-task-delay.js
+++ b/src/use-async-task-delay.js
@@ -13,10 +13,11 @@ const createAbortError = (message) => {
 };
 
 export const useAsyncTaskDelay = delay => useAsyncTask(useCallback(
-  abortController => new Promise((resolve, reject) => {
+  (abortController, delayOverride) => new Promise((resolve, reject) => {
+    const delayToUse = delayOverride || delay;
     const id = setTimeout(() => {
       resolve(true);
-    }, typeof delay === 'function' ? delay() : delay);
+    }, typeof delayToUse === 'function' ? delayToUse() : delayToUse);
     abortController.signal.addEventListener('abort', () => {
       clearTimeout(id);
       reject(createAbortError('timer aborted'));

--- a/src/use-async-task-fetch.js
+++ b/src/use-async-task-fetch.js
@@ -17,10 +17,11 @@ export const useAsyncTaskFetch = (
   init = defaultInit,
   readBody = defaultReadBody,
 ) => useAsyncTask(useCallback(
-  async (abortController) => {
-    const response = await fetch(input, {
-      signal: abortController.signal,
+  async (abortController, inputOverride, initOverride) => {
+    const response = await fetch(inputOverride || input, {
       ...init,
+      ...initOverride,
+      signal: abortController.signal,
     });
     if (!response.ok) {
       throw createFetchError(response.statusText);

--- a/src/use-async-task-timeout.js
+++ b/src/use-async-task-timeout.js
@@ -13,10 +13,11 @@ const createAbortError = (message) => {
 };
 
 export const useAsyncTaskTimeout = (func, delay) => useAsyncTask(useCallback(
-  abortController => new Promise((resolve, reject) => {
+  (abortController, delayOverride) => new Promise((resolve, reject) => {
+    const delayToUse = delayOverride || delay;
     const id = setTimeout(() => {
       resolve(func());
-    }, delay);
+    }, delayToUse);
     abortController.signal.addEventListener('abort', () => {
       clearTimeout(id);
       reject(createAbortError('timer aborted'));

--- a/src/use-async-task-wasm.js
+++ b/src/use-async-task-wasm.js
@@ -9,8 +9,11 @@ export const useAsyncTaskWasm = (
   input,
   importObject = defaultImportObject,
 ) => useAsyncTask(useCallback(
-  async (abortController) => {
-    const response = await fetch(input, {
+  async (abortController, inputOverride) => {
+    const inputToUse = (
+      typeof input === 'object' && typeof inputOverride === 'object'
+    ) ? { ...input, ...inputOverride } : (inputOverride || input);
+    const response = await fetch(inputToUse, {
       signal: abortController.signal,
     });
     if (!response.ok) {


### PR DESCRIPTION
As we discussed in #17, this is to add two new features.
- custom args
- reusable tasks

These are not breaking change.
But there's a caveat: `onClick={start}` fails, it should be `onClick={() => start()}`.