### PR TITLE
task.start now returns a promsie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- task.start returns a promise (#28)
 
 ## [3.4.2] - 2019-09-17
 ### Changed

--- a/dist/use-async-task.js
+++ b/dist/use-async-task.js
@@ -80,7 +80,7 @@ var createTask = function createTask(func, forceUpdate) {
                   break;
                 }
 
-                return _context.abrupt("return");
+                return _context.abrupt("return", null);
 
               case 2:
                 task.abort();
@@ -122,7 +122,17 @@ var createTask = function createTask(func, forceUpdate) {
                   forceUpdate();
                 }
 
-              case 24:
+                if (!err) {
+                  _context.next = 26;
+                  break;
+                }
+
+                throw err;
+
+              case 26:
+                return _context.abrupt("return", result);
+
+              case 27:
               case "end":
                 return _context.stop();
             }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 export type AsyncTask<Result, Args extends unknown[] = unknown[]> = {
-  start: (...args: Args) => void;
+  start: (...args: Args) => Promise<Result | null>;
   abort: () => void;
   started: boolean;
 } & (

--- a/src/use-async-task.js
+++ b/src/use-async-task.js
@@ -16,7 +16,7 @@ const createTask = (func, forceUpdate) => {
     start: async (...args) => {
       if (task.id === null) {
         // already cleaned up
-        return;
+        return null;
       }
       task.abort();
       task.abortController = new AbortController();
@@ -41,6 +41,8 @@ const createTask = (func, forceUpdate) => {
         task.pending = false;
         forceUpdate();
       }
+      if (err) throw err;
+      return result;
     },
     abort: () => {
       if (task.abortController) {


### PR DESCRIPTION
Fixes #27 

I thought it was not trivial and use-async-combine-* needed to be modified, but it turns out to be unnecessary.