### PR TITLE
Don't throw an error when request is aborted

### DIFF
--- a/src/use-async-task.js
+++ b/src/use-async-task.js
@@ -26,7 +26,9 @@ const createTask = (func, forceUpdate) => {
       try {
         result = await func(task.abortController, ...args);
       } catch (e) {
-        err = e;
+        if (e.name !== 'AbortError') {
+          err = e;
+        }
       }
       if (task.id === taskId) {
         task.result = result;


### PR DESCRIPTION
Currently, when a fetchTask is aborted, an error is thrown. The problem is that abort behavior is wanted, either executed by the user or by the module itself to reset the request.

It should not throw an error and pollute the console.

Fixes #30 