### PR TITLE
avoid warning in ssr

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
   },
   "rules": {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "error",
+    "react-hooks/exhaustive-deps": ["error", { "additionalHooks": "useIsomorphicLayoutEffect" }],
     "@typescript-eslint/explicit-function-return-type": "off",
     "react/jsx-filename-extension": ["error", { "extensions": [".js", ".tsx"] }],
     "react/prop-types": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
   },
   "rules": {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": ["error", { "additionalHooks": "useIsomorphicLayoutEffect" }],
+    "react-hooks/exhaustive-deps": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "react/jsx-filename-extension": ["error", { "extensions": [".js", ".tsx"] }],
     "react/prop-types": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Changed
-- Use useIsomorphicLayoutEffect hack to avoid warning in SSR
+- Do not useLayoutEffect which shows warning in SSR
 
 ## [3.8.0] - 2019-11-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Use useIsomorphicLayoutEffect hack to avoid warning in SSR
 
 ## [3.8.0] - 2019-11-26
 ### Changed

--- a/src/use-async-task.js
+++ b/src/use-async-task.js
@@ -1,4 +1,6 @@
-import { useLayoutEffect, useReducer, useRef } from 'react';
+import { useEffect, useLayoutEffect, useReducer, useRef } from 'react';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const createTask = ({ func, dispatchRef }) => {
   const taskId = Symbol('TASK_ID');
@@ -98,7 +100,7 @@ export const useAsyncTask = (func) => {
   if (task.func !== func) {
     dispatch({ type: 'INIT', func, dispatchRef });
   }
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     dispatchRef.current = dispatch;
     const cleanup = () => {
       dispatchRef.current = () => {};

--- a/src/use-async-task.js
+++ b/src/use-async-task.js
@@ -1,6 +1,4 @@
-import { useEffect, useLayoutEffect, useReducer, useRef } from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import { useEffect, useReducer, useRef } from 'react';
 
 const createTask = ({ func, dispatchRef }) => {
   const taskId = Symbol('TASK_ID');
@@ -100,8 +98,8 @@ export const useAsyncTask = (func) => {
   if (task.func !== func) {
     dispatch({ type: 'INIT', func, dispatchRef });
   }
-  useIsomorphicLayoutEffect(() => {
-    dispatchRef.current = dispatch;
+  dispatchRef.current = dispatch;
+  useEffect(() => {
     const cleanup = () => {
       dispatchRef.current = () => {};
     };


### PR DESCRIPTION
The use of useLayoutEffect shows warning in SSR. https://github.com/facebook/react/issues/14927

~This is an easy fix. It doesn't help if window is polyfilled.
(But, currently I don't feel like using a complex hack like https://github.com/alloc/react-layout-effect.)~

Originally reported by @alvinthen in https://github.com/dai-shi/react-hooks-async/pull/33#issuecomment-559365883.